### PR TITLE
Allow to measure the number of lines of a text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,37 @@ performance.
 ### Usage
 
 This addon just provides a service that you can inject wherever you need.
-The service for now has one single method `width(string, font = null)` that will
-return the width of the text with the given font information.
+
+The service for now has two methods:
+
+* `width(string, font = null)` will return the width of the text with the given font information.
 
 ```js
 textMeasurer.width('foobar', '24px Arial');             // ~ 68.02px
 textMeasurer.width('foobar', '20px Arial');             // ~ 56.64px
 textMeasurer.width('foobar', '20px Times New Roman');   // ~ 52.19px
 ```
+
+* `lines(string, width, font = null)` will return the number of lines that this text would
+  require when rendered in a container of the given width with the given font.
+
+```js
+const sampleMultilineText = `Lorem
+ipsum dolor sit amet, ex legimus mandamus sea, qui no doctus option. Ei pri commune maiestatis. Mea at facete appetere tincidunt. Et sea quaestio expetendis. No eius virtute delenit per.
+
+
+Ea mel error latine, usu harum delicata forensibus id, ut est probo quodsi regione. Sumo definitiones ex has, percipit voluptatum an qui. Eius solet aeterno sea ut, qui ex inani persequeris. In nostro facilis consetetur mea. Ut audiam virtute nostrum eam, omnes luptatum splendide eam at.
+
+Veri zril ex vel, pri habemus delicata et. Te minimum expetenda dissentiet est, homero omnium expetenda no pri, enim fuisset usu ei. Mel ex quidam scripserit, pri aliquip debitis id. Vis ea legere persius recteque, utamur blandit volutpat ea vel.`;
+
+textMeasurer.lines(sampleMultilineText, 400, 'normal 24px Helvetica'); // 26 lines
+textMeasurer.lines(sampleMultilineText, 600, 'normal 24px Helvetica'); // 19 lines
+textMeasurer.lines(sampleMultilineText, 600, 'normal 14px Helvetica'); // 14 lines
+```
+
+_Please note than measuring the lines is significantly more expensive than measuting the width
+and might take a non-negligible amount of time when performed on text over a few thousands words, and
+results might not be accurate on browsers that don't have subpixel precission on text measurements_
 
 ### What can I do with this?
 

--- a/addon/services/text-measurer.js
+++ b/addon/services/text-measurer.js
@@ -8,9 +8,36 @@ export default Ember.Service.extend({
   },
 
   width(string, font = null) {
-    if (font) {
-      this.ctx.font = font;
-    }
+    if (font) { this.ctx.font = font; }
     return this.ctx.measureText(string).width;
+  },
+
+  lines(string, maxWidth, font = null) {
+    if (font) { this.ctx.font = font; }
+    let paragraphs = string.split(/\n/);
+    let lines = paragraphs.length;
+    for (let i = 0; i < paragraphs.length; i++) {
+      let paragraph = paragraphs[i];
+      if (paragraph !== '') {
+        let words = paragraph.split(' ');
+        let widthSoFar = 0;
+        let j = 0;
+        for (; j < words.length - 1; j++) {
+          let wordWidth = this.ctx.measureText(words[j] + ' ').width;
+          widthSoFar = widthSoFar + wordWidth;
+          if (widthSoFar > maxWidth) {
+            lines++;
+            widthSoFar = wordWidth;
+          }
+        }
+        let wordWidth = this.ctx.measureText(words[j]).width;
+        widthSoFar = widthSoFar + wordWidth;
+        if (widthSoFar > maxWidth) {
+          lines++;
+          widthSoFar = wordWidth;
+        }
+      }
+    }
+    return lines;
   }
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,11 +1,21 @@
 import Ember from 'ember';
 const { Controller, String: { htmlSafe }, inject: { service }, computed } = Ember;
 
+const sampleMultilineText = `Lorem
+ipsum dolor sit amet, ex legimus mandamus sea, qui no doctus option. Ei pri commune maiestatis. Mea at facete appetere tincidunt. Et sea quaestio expetendis. No eius virtute delenit per.
+
+
+
+Ea mel error latine, usu harum delicata forensibus id, ut est probo quodsi regione. Sumo definitiones ex has, percipit voluptatum an qui. Eius solet aeterno sea ut, qui ex inani persequeris. In nostro facilis consetetur mea. Ut audiam virtute nostrum eam, omnes luptatum splendide eam at.
+
+Veri zril ex vel, pri habemus delicata et. Te minimum expetenda dissentiet est, homero omnium expetenda no pri, enim fuisset usu ei. Mel ex quidam scripserit, pri aliquip debitis id. Vis ea legere persius recteque, utamur blandit volutpat ea vel.`;
+
 export default Controller.extend({
   textMeasurer: service(),
   demo1text: '',
   demo2text: 'Hello world',
   demo2width: 200,
+  demo3text: sampleMultilineText,
 
   // CPs
   demo1Style: computed('demo1text', function() {
@@ -19,5 +29,13 @@ export default Controller.extend({
     let width = measurer.width(demo2text, '16px Arial');
     let ratio = (demo2width - 4) / width;
     return htmlSafe(`width: ${demo2width}px; font-size: ${16 * ratio}px;`);
+  }),
+
+  demo3lines: computed('demo3text', function() {
+    let { demo3text, textMeasurer: measurer } = this.getProperties('demo3text', 'textMeasurer');
+    console.time('measure');
+    let result = measurer.lines(demo3text, 300, "normal normal normal normal 11px / normal BlinkMacSystemFont");
+    console.timeEnd('measure');
+    return result;
   })
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -32,5 +32,16 @@
 <div id="demo-2" style={{demo2Style}}>{{demo2text}}</div>
 
 <p>
-  All at 60fps :D
+  You can also use the <code>lines</code> method to approximate the number of lines a text will
+  require on a textarea, perhaps to make it grow automatically.
 </p>
+<textarea rows={{demo3lines}} value={{demo3text}} oninput={{action (mut demo3text) value="target.value"}} style="padding: 0; width: 300px; resize: none;"></textarea>
+<p>The number of lines is: {{demo3lines}}</p>
+
+<em>
+  Please note than measuring lines is a far more expensive calculation
+  than measuring width.
+  While still pretty fast, texts over a few thousand words might take a noticiable
+  time.
+</em>
+

--- a/tests/unit/services/text-measurer-test.js
+++ b/tests/unit/services/text-measurer-test.js
@@ -5,6 +5,15 @@ function decimalRound(number, decimals = 0) {
   return Math.round(number * factor) / factor;
 }
 
+const sampleMultilineText = `Lorem
+ipsum dolor sit amet, ex legimus mandamus sea, qui no doctus option. Ei pri commune maiestatis. Mea at facete appetere tincidunt. Et sea quaestio expetendis. No eius virtute delenit per.
+
+
+
+Ea mel error latine, usu harum delicata forensibus id, ut est probo quodsi regione. Sumo definitiones ex has, percipit voluptatum an qui. Eius solet aeterno sea ut, qui ex inani persequeris. In nostro facilis consetetur mea. Ut audiam virtute nostrum eam, omnes luptatum splendide eam at.
+
+Veri zril ex vel, pri habemus delicata et. Te minimum expetenda dissentiet est, homero omnium expetenda no pri, enim fuisset usu ei. Mel ex quidam scripserit, pri aliquip debitis id. Vis ea legere persius recteque, utamur blandit volutpat ea vel.`;
+
 moduleFor('service:text-measurer', 'Unit | Service | text measurer');
 
 // Note: The actual results of this tests vary from browser to browser depending
@@ -14,16 +23,23 @@ moduleFor('service:text-measurer', 'Unit | Service | text measurer');
 // Those numbers are correct for Firefox in Ubuntu, but it is expected that
 // running these tests in a different browser/OS will fail.
 
-test('#measure receives a string and returns its width', function(assert) {
+test('#width receives a string and returns its width', function(assert) {
   let service = this.subject();
   assert.equal(decimalRound(service.width('foobar'), 1), 32);
   assert.equal(decimalRound(service.width('iiiiii'), 1), 18);
   assert.equal(decimalRound(service.width('mmmmmm'), 1), 60);
 });
 
-test('#measure optionally accepts a font definition to apply to the string being measured', function(assert) {
+test('#width optionally accepts a font definition to apply to the string being measured', function(assert) {
   let service = this.subject();
   assert.equal(decimalRound(service.width('foobar', 'normal 24px Helvetica'), 1), 67);
   assert.equal(decimalRound(service.width('foobar', 'normal 20px Helvetica'), 1), 57);
   assert.equal(decimalRound(service.width('foobar', 'normal 20px Times'), 1), 53);
+});
+
+test('#lines(string, width, font?) returns the number of lines that a text would require in the given width', function(assert) {
+  let service = this.subject();
+  assert.equal(service.lines(sampleMultilineText, 400, 'normal 24px Helvetica'), 27);
+  assert.equal(service.lines(sampleMultilineText, 600, 'normal 24px Helvetica'), 20);
+  assert.equal(service.lines(sampleMultilineText, 600, 'normal 14px Helvetica'), 15);
 });


### PR DESCRIPTION
The algoritm is reasonably performant, but I suspect that it might be unnacurate
in browsers that don't give you sub-pixel precission on font dimensions.
